### PR TITLE
feat: Implement fixed header and responsive content padding

### DIFF
--- a/website/styles.css
+++ b/website/styles.css
@@ -135,6 +135,11 @@ header {
   color: var(--color-light);
   padding: 0; /* Remove header padding, let sections inside control it */
   box-shadow: var(--box-shadow-sm); /* Keep this for the overall header block */
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1000;
 }
 
 /* Navigation */
@@ -223,7 +228,7 @@ nav.site-navigation li.submenu-active > ul { /* For click nav from main.js */
 
 /* Main Content */
 main {
-  padding: var(--space-xl) 0; /* Use container for side padding */
+  padding: 180px 0 var(--space-xl); /* Use container for side padding */
 }
 
 /* Styling for the container of articles on index.html */
@@ -429,6 +434,10 @@ footer p {
   nav.site-navigation ul ul li a:hover,
   nav.site-navigation ul ul li a:focus {
     background-color: var(--color-primary); /* Lighter shade for hover */
+  }
+
+  main {
+    padding: 300px 0 var(--space-xl); /* Adjusted top padding for mobile */
   }
 }
 


### PR DESCRIPTION
Makes the main site header fixed to the top of the viewport. Adjusts the top padding of the main content area to prevent overlap with the fixed header.

Includes responsive adjustments:
- Desktop: Sets main content top padding to 180px.
- Mobile (screens < 767.98px): Sets main content top padding to 300px to accommodate the taller header layout on smaller devices.

This ensures the header is always visible while scrolling and maintains a good layout on both desktop and mobile views.