### PR TITLE
Fix: Ensure logo and title are side-by-side on mobile

### DIFF
--- a/website/styles.css
+++ b/website/styles.css
@@ -393,12 +393,14 @@ footer p {
 @media (max-width: 767.98px) {
   /* --- Styles for .header-title-area on mobile --- */
   .header-title-area {
-    padding: var(--space-sm) var(--space-md); /* Reduce padding */
+    padding: var(--space-xs) var(--space-md); /* Reduce padding */
   }
 
   .header-title-area h1 {
-    font-size: var(--font-size-xl); /* Slightly smaller title on mobile */
+    font-size: var(--font-size-lg); /* Slightly smaller title on mobile */
     /* Vertical margins are effectively 0 from desktop .header-title-area h1 rule */
+    flex-shrink: 1;
+    min-width: 0;
   }
 
   .logo-title-wrapper { /* Mobile specific override */
@@ -407,9 +409,10 @@ footer p {
   }
 
   .site-logo { /* Mobile specific override */
-    height: 50px; /* Reduce logo height */
+    height: 40px; /* Reduce logo height */
     margin-bottom: 0; /* Remove bottom margin */
     margin-right: var(--space-sm); /* Add right margin for spacing */
+    flex-shrink: 0;
   }
 
   /* --- Styles for nav.site-navigation on mobile --- */


### PR DESCRIPTION
I modified CSS for the header on mobile devices (`max-width: 767.98px`):
- Ensured `.logo-title-wrapper` uses `flex-wrap: nowrap;`.
- Added `flex-shrink: 1;` and `min-width: 0;` to `.header-title-area h1` to allow the title to shrink if space is limited.
- Added `flex-shrink: 0;` to `.site-logo` to prevent the logo from shrinking.

These changes address an issue where the logo and title would stack vertically on narrow mobile screens. They should now remain side-by-side, with the title text compressing as needed.