### PR TITLE
Fix: Improve mobile layout for workout tables

### DIFF
--- a/website/pages/physical_training/offseason_gym_workouts/OffseasonWorkOut01.html
+++ b/website/pages/physical_training/offseason_gym_workouts/OffseasonWorkOut01.html
@@ -96,13 +96,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Hang Cleans
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           4 x 5
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on explosive hip extension.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/WCdhjfg7fv4" title="Hang Clean 01">
@@ -115,13 +115,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Trap Bar Deadlifts
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           4 x 5
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Maintain a flat back; drive through the heels.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/oc3X4oUaeZs" title="Trap Bar Deadlift 01">
@@ -134,13 +134,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Broad Jumps
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 5
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on maximum horizontal distance and controlled landing.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/6L6CJXF5CNs" title="Broad Jump 01">
@@ -149,13 +149,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Sled Pushes
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           5 x 15-yards
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on powerful leg drive and maintaining a forward lean.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/BCexQ27DWIE" title="Sled Push">
@@ -164,13 +164,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Single-Leg Bulgarian Split Squats
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 8 (per leg)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Maintain balance and control; ensure front knee tracks over ankle.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/or1frhkjBDc" title="Bulgarian Split Squats 01">
@@ -179,13 +179,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Explosive Step-Ups
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 6 (per leg)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Drive explosively off the front leg; use a challenging but safe box height.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/vnP-ZKi0ZAM" title="Explosive Step-Ups 01">
@@ -231,13 +231,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+          <td data-label="Exercise">
           Incline Bench Press
          </td>
-         <td>
+          <td data-label="Sets x Reps">
           4 x 6
          </td>
-         <td>
+          <td data-label="Notes / Video">
           Focus on controlled movement and chest activation.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/98HWfiRonkE" title="Incline Bench Press 01">
@@ -246,13 +246,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+          <td data-label="Exercise">
           Pull-Ups (or Lat Pulldowns)
          </td>
-         <td>
+          <td data-label="Sets x Reps">
           3 x 10 (or to failure)
          </td>
-         <td>
+          <td data-label="Notes / Video">
           Use assistance if needed, or substitute with Lat Pulldowns.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/eDP_OOhMTZ4" title="Pull-Up 01">
@@ -261,13 +261,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+          <td data-label="Exercise">
           Bent Over Rows
          </td>
-         <td>
+          <td data-label="Sets x Reps">
           3 x 10
          </td>
-         <td>
+          <td data-label="Notes / Video">
           Maintain a flat back; pull towards the lower chest.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/phVtqawIgbk" title="Bent Over Row 01">
@@ -276,13 +276,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+          <td data-label="Exercise">
           Standing Barbell Shoulder Press
          </td>
-         <td>
+          <td data-label="Sets x Reps">
           3 x 8
          </td>
-         <td>
+          <td data-label="Notes / Video">
           Engage core; press overhead without excessive arching.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/zoN5EH50Dro" title="Standing Overhead Press 01">
@@ -291,13 +291,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+          <td data-label="Exercise">
           Flat Dumbbell Flyes
          </td>
-         <td>
+          <td data-label="Sets x Reps">
           3 x 12
          </td>
-         <td>
+          <td data-label="Notes / Video">
           Focus on chest stretch and adduction.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/rk8YayRoTRQ" title="Flat Dumbbell Fly 01">
@@ -329,13 +329,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Plank
          </td>
-         <td>
+         <td data-label="Duration/Reps">
           30-60 seconds
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Maintain a straight line from head to heels.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/pSHjTRCQxIw" title="Plank">
@@ -344,13 +344,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Side Plank
          </td>
-         <td>
+         <td data-label="Duration/Reps">
           30 seconds per side
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Keep hips lifted and body aligned.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/sKMD_pbNm7w" title="Side Plank">
@@ -359,13 +359,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Russian Twists
          </td>
-         <td>
+         <td data-label="Duration/Reps">
           15-20 reps per side
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Rotate torso, not just arms. Add weight for challenge.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/wkD8rjkodUI" title="Russian Twist">
@@ -448,46 +448,46 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Box Jumps (or Tuck Jumps)
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           3 x 8-10
          </td>
-         <td>
+         <td data-label="Notes">
           Focus on explosive upward movement and soft landings.
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Lateral Bounds
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           3 x 8-10 per leg
          </td>
-         <td>
+         <td data-label="Notes">
           Focus on distance and control, absorb landing.
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Cone Drills (e.g., Figure 8, 5-10-5 Shuttle)
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           3-5 reps each drill
          </td>
-         <td>
+         <td data-label="Notes">
           Focus on quick feet, low center of gravity, and sharp cuts. (Use any markers if cones aren't available)
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Plank Variations (e.g., Plank with leg lift)
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           3 x 30-45 seconds
          </td>
-         <td>
+         <td data-label="Notes">
           Maintain core stability.
          </td>
         </tr>
@@ -535,13 +535,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+          <td data-label="Exercise">
           Back Squat
          </td>
-         <td>
+          <td data-label="Sets x Reps">
           4 x 8
          </td>
-         <td>
+          <td data-label="Notes / Video">
           Focus on depth and maintaining an upright torso.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/Ak1iHbEeeY8" title="Back Squat 01">
@@ -554,13 +554,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Romanian Deadlifts (RDLs)
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           4 x 8
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on hamstring stretch and maintaining a flat back.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/Wou9zVQrAfs" title="Romanian Deadlift">
@@ -569,13 +569,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Partner Glute-Ham Raises or Nordic Curls
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           4 x 8 (or as many as possible with good form)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on controlled eccentric movement.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/Lsq7ztSjIYA" title="Partner Glute-Ham Raise">
@@ -588,13 +588,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Dumbbell Step-Ups
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           4 x 8 (per leg)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on driving through the front heel; control the descent.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/JFQx5avgKus" title="Dumbbell Step-Up">
@@ -603,13 +603,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Rotational Med Ball Slams
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 10 (per side)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Generate power from hips and core; slam forcefully.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/T_XkIEfDtP8" title="Rotational Med Ball Slam 01">
@@ -618,13 +618,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Cable Woodchoppers
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 12 (per side)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Control the movement through the full range of motion.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/iTmMPyDzeYA" title="Cable Woodchopper">
@@ -633,13 +633,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Ab Wheel Rollouts or Hanging Leg Raises
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 8-12 (or to failure)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Maintain core tension; avoid arching the lower back for Ab Wheel. For Leg Raises, aim for full range of motion.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/EXTVAbDdvAc" title="Ab Wheel Rollouts for Beginners">
@@ -689,13 +689,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+          <td data-label="Exercise">
           Push Press or Landmine Press
          </td>
-         <td>
+          <td data-label="Sets x Reps">
           4 x 5
          </td>
-         <td>
+          <td data-label="Notes / Video">
           Focus on transferring power from legs through the upper body. Choose one variation.
           <p>
            Push Press:
@@ -714,13 +714,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Medicine Ball Chest Pass (Explosive)
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 10
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on maximum power and speed with each pass.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/fYp7wBoZ_Ms" title="Medicine Ball Chest Pass 01">
@@ -729,13 +729,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Explosive Pushups (Clapping or Standard)
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 10
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on pushing up as explosively as possible.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/YJJTSyOEm1k" title="Explosive Pushups 01">
@@ -764,13 +764,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Rope Climbs or Rope Pulls
          </td>
-         <td>
+         <td data-label="Sets x Reps/Duration">
           3 x 5 ascents/pulls (or to failure)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on using grip and upper body.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/YN7DcLUSTEs" title="Rope Climb Technique">
@@ -779,13 +779,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Farmer's Carries
          </td>
-         <td>
+         <td data-label="Sets x Reps/Duration">
           3 x 40-yards
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Use heavy dumbbells/kettlebells; maintain posture and strong grip.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/vi4X2iSOyiA" title="Farmers Carry Technique">
@@ -794,13 +794,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Plate Pinches
          </td>
-         <td>
+         <td data-label="Sets x Reps/Duration">
           3 x 45-seconds per hand
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Pinch two plates together, smooth side out.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/jFTV3DQf3HE" title="Plate Pinch Grip Strength Exercise 01">

--- a/website/pages/physical_training/offseason_gym_workouts/OffseasonWorkOut02.html
+++ b/website/pages/physical_training/offseason_gym_workouts/OffseasonWorkOut02.html
@@ -96,13 +96,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Back Squats
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           4 x 6
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on proper form, depth, and controlled movement.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/Ak1iHbEeeY8" title="Back Squat 01">
@@ -115,13 +115,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Romanian Deadlifts (RDLs)
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 8
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Maintain a slight bend in the knees, focus on hamstring and glute engagement.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/Wou9zVQrAfs" title="Romanian Deadlift">
@@ -130,13 +130,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Walking Lunges
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 10 (each leg)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Keep torso upright, ensure front knee tracks over ankle.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/1kMf9COA1Iw" title="Walking Lunges">
@@ -145,13 +145,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Box Jumps
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 5
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on explosive jump and soft, controlled landing. Start with a comfortable box height.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/9CWjnuMaXXE" title="Box Jumps">
@@ -160,13 +160,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Calf Raises
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 15
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Perform slowly, focusing on full range of motion.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/nFKYH_j3GOc" title="Calf Raises">
@@ -195,13 +195,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Plank Holds
          </td>
-         <td>
+         <td data-label="Sets x Reps/Duration">
           3 x 1-minute
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Maintain a straight line from head to heels, engage core.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/v25dawSzRTM" title="Plank holds">
@@ -210,13 +210,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Russian Twists
          </td>
-         <td>
+         <td data-label="Sets x Reps/Duration">
           3 x 20 (10 per side)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Rotate torso, keep hips stable. Add weight for increased difficulty.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/aRUMRbl7KS4" title="Russian Twists">
@@ -262,13 +262,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Incline Bench Press
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           4 x 6
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on controlled descent and explosive press.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/98HWfiRonkE" title="Incline Bench Press 01">
@@ -277,13 +277,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Pull-Ups (or Lat Pulldowns)
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x max reps (or 3 x 8-10 for Lat Pulldowns)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Aim for full range of motion. Use assistance if needed for Pull-Ups.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/eDP_OOhMTZ4" title="Pull-Up 01">
@@ -292,13 +292,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Dumbbell Shoulder Press
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 8
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Keep core engaged; press dumbbells overhead without excessive arching.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/k6tzKisR3NY" title="Dumbbell Shoulder Press 01">
@@ -307,13 +307,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Bent-Over Rows
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 10
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Maintain a flat back; pull the weight towards your lower rib cage.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/p9RihhjmJsw" title="Bent Over Row 01">
@@ -322,13 +322,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Face Pulls
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 12
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on squeezing shoulder blades together; great for shoulder health.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/IeOqdw9WI90" title="Face Pulls 01">
@@ -357,13 +357,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Hanging Leg Raises (or Knee Tucks)
          </td>
-         <td>
+         <td data-label="Sets x Reps/Duration">
           3 x 10-15
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Control the movement; avoid swinging.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/7FwGZ8qY5OU" title="Hanging Leg Raises 01">
@@ -372,13 +372,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Side Planks
          </td>
-         <td>
+         <td data-label="Sets x Reps/Duration">
           3 x 30 seconds (each side)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Maintain a straight line from head to feet; keep hips lifted.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/sKMD_pbNm7w" title="Side Planks">
@@ -458,46 +458,46 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Cone Drills (e.g., 4-Cone Box Drill, T-Drill)
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           3-5 reps per drill
          </td>
-         <td>
+         <td data-label="Notes">
           Focus on quick feet, hip turns, and accelerating out of breaks. (Use any markers if cones unavailable)
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Broad Jumps (forwards and lateral)
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           3 x 5-8 reps
          </td>
-         <td>
+         <td data-label="Notes">
           Focus on explosive power and controlled landings.
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Backpedal to Sprint
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           3 x 10-15 yards (backpedal) + 10-15 yards (sprint)
          </td>
-         <td>
+         <td data-label="Notes">
           Focus on smooth transition from backpedal to forward sprint.
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Plyometric Push-ups (or standard)
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           3 x 8-10
          </td>
-         <td>
+         <td data-label="Notes">
           Develop upper body explosiveness useful for shedding blocks.
          </td>
         </tr>
@@ -551,13 +551,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Kettlebell Swings
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           15 reps
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Focus on hip hinge and explosive power.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/9FT2lQQNF9Q" title="Kettlebell Swings 01">
@@ -566,13 +566,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Push-Ups
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           20 reps
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Maintain good form; modify to knees if necessary.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/4Bc1tPaYkOo" title="Push-Ups 01">
@@ -581,13 +581,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Goblet Squats
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           15 reps
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Keep chest up and back straight; squat to depth.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/cssx0dfq3Wg" title="Goblet Squats">
@@ -596,13 +596,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Battle Ropes
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           30 seconds
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Maintain intensity; try different variations (waves, slams).
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/ZEAqK0lXnb0" title="Battle Ropes 01">
@@ -611,13 +611,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Farmer's Carry
          </td>
-         <td>
+         <td data-label="Reps/Duration">
           40 yards
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Use challenging weight; maintain upright posture and strong grip.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/-LwASAVMEek" title="Farmer's Carry 01">
@@ -646,13 +646,13 @@
        </thead>
        <tbody>
         <tr>
-         <td>
+         <td data-label="Exercise">
           Plank with Shoulder Taps
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 20 total taps (10 per side)
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Minimize hip rotation; maintain core stability.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/wcKyqAMqueQ" title="Plank with Shoulder Taps">
@@ -661,13 +661,13 @@
          </td>
         </tr>
         <tr>
-         <td>
+         <td data-label="Exercise">
           V-Ups
          </td>
-         <td>
+         <td data-label="Sets x Reps">
           3 x 15 reps
          </td>
-         <td>
+         <td data-label="Notes / Video">
           Aim for simultaneous hand and foot touch; modify to tuck-ups if needed.
           <div class="video-container">
            <iframe allowfullscreen loading="lazy" src="https://www.youtube.com/embed/BIOM5eSsJ_8" title="V-Ups 01">

--- a/website/styles.css
+++ b/website/styles.css
@@ -774,7 +774,7 @@ footer p {
 }
 
 /* Responsive adjustments for tabs if needed */
-@media (max-width: 767.98px) { /* Mobile styles from existing CSS */
+@media (max-width: 767.98px) {
   .workout-tabs {
     flex-direction: column; /* Stack tabs vertically on small screens */
     border-bottom: none; /* Remove bottom border for vertical tabs */
@@ -803,5 +803,31 @@ footer p {
   .workout-tab-panel {
     border-top: 2px solid var(--color-border); /* Add top border back for panels when tabs are stacked */
     border-radius: var(--border-radius); /* Consistent rounding */
+  }
+
+  /* Workout Table Mobile Styles */
+  .workout-table thead {
+    display: none; /* Hide table headers on mobile */
+  }
+  .workout-table tr,
+  .workout-table td {
+    display: block;
+    width: 100%;
+  }
+  .workout-table td {
+    border-bottom: 1px solid var(--color-border); /* Add a separator for stacked cells */
+    padding-top: var(--space-md);
+    padding-bottom: var(--space-md);
+  }
+  .workout-table tr:last-child td:last-child {
+    border-bottom: none; /* Remove border from the very last cell in the table */
+  }
+  /* Add a label for each cell using the data-label attribute */
+  .workout-table td:before {
+    content: attr(data-label);
+    font-weight: bold;
+    display: block;
+    margin-bottom: var(--space-sm);
+    color: var(--color-primary);
   }
 }


### PR DESCRIPTION
The tables in OffseasonWorkOut01.html and OffseasonWorkOut02.html were difficult to use on mobile devices, especially the 'Notes / Video' section.

This commit implements the following changes:
- Modifies styles.css to make table rows stack vertically on screens narrower than 768px.
- Hides table headers (thead) on mobile.
- Adds data-label attributes to table cells (td) in the HTML, which are displayed via CSS ::before pseudo-elements on mobile to provide context for each piece of data in the stacked layout.
- Ensures that the 'Notes / Video' content (text and videos) utilizes the full width in the stacked mobile view.

The desktop layout of the tables remains unchanged. Conceptual testing confirmed the expected behavior on both mobile and desktop views.