### PR TITLE
Refactor: Improve layout of WR routes section

### DIFF
--- a/website/pages/football_101/offense/theWideReceiver.html
+++ b/website/pages/football_101/offense/theWideReceiver.html
@@ -55,72 +55,93 @@
             </div>
             </section>
 
-            <section>
-                <p>
-                Below are fundamental routes every young receiver should know. These are the foundation for building more advanced concepts.
-                </p>
-                <h3>0. Screen</h3>
-                <p><strong>Setup:</strong> Varies by concept—can be to WRs (bubble/tunnel) or RBs (slip). Timing and alignment must match the blocking scheme.</p>
+            <p style="margin-top: var(--space-lg); margin-bottom: var(--space-md);">
+            Below are fundamental routes every young receiver should know. These are the foundation for building more advanced concepts.
+            </p>
+            <section class="route-grid-container">
+                <article class="route-card">
+                    <h3>Screen: Bubble</h3>
+                    <p><strong>Setup:</strong> Slot or outside receiver. Time your drop step to get behind the line.</p>
+                    <p><strong>Directions:</strong> Backpedal or slide outside to receive the ball behind the LOS while other WRs block in space.</p>
+                    <p><strong>Tips:</strong> Secure the catch first, then attack the alley with urgency. Use your blockers.</p>
+                </article>
 
-                <h4>Bubble Screen</h4>
-                <p><strong>Setup:</strong> Slot or outside receiver. Time your drop step to get behind the line.</p>
-                <p><strong>Directions:</strong> Backpedal or slide outside to receive the ball behind the LOS while other WRs block in space.</p>
-                <p><strong>Tips:</strong> Secure the catch first, then attack the alley with urgency. Use your blockers.</p>
+                <article class="route-card">
+                    <h3>Screen: Slip</h3>
+                    <p><strong>Setup:</strong> Running back aligned next to or behind the QB.</p>
+                    <p><strong>Directions:</strong> Delay your release to sell pass protection, then slip into the flat or middle.</p>
+                    <p><strong>Tips:</strong> Stay patient and hidden behind the line. Trust the linemen to release and set up lanes.</p>
+                </article>
 
-                <h4>Slip Screen</h4>
-                <p><strong>Setup:</strong> Running back aligned next to or behind the QB.</p>
-                <p><strong>Directions:</strong> Delay your release to sell pass protection, then slip into the flat or middle.</p>
-                <p><strong>Tips:</strong> Stay patient and hidden behind the line. Trust the linemen to release and set up lanes.</p>
+                <article class="route-card">
+                    <h3>Screen: Tunnel</h3>
+                    <p><strong>Setup:</strong> Outside or slot receiver. Start with a vertical or angled stem.</p>
+                    <p><strong>Directions:</strong> Take 1–2 steps upfield, then loop back inside behind the LOS toward the QB. Catch and follow inside blockers.</p>
+                    <p><strong>Tips:</strong> Don’t drift upfield. Let the tunnel form, then hit it at full speed once the catch is secure.</p>
+                </article>
 
-                <h4>Tunnel Screen</h4>
-                <p><strong>Setup:</strong> Outside or slot receiver. Start with a vertical or angled stem.</p>
-                <p><strong>Directions:</strong> Take 1–2 steps upfield, then loop back inside behind the LOS toward the QB. Catch and follow inside blockers.</p>
-                <p><strong>Tips:</strong> Don’t drift upfield. Let the tunnel form, then hit it at full speed once the catch is secure.</p>
+                <article class="route-card">
+                    <h3>1. Flat</h3>
+                    <p><strong>Setup:</strong> Usually from a tight or slot alignment. May motion to adjust leverage.</p>
+                    <p><strong>Directions:</strong> Release horizontally toward the sideline, staying flat and gaining width.</p>
+                    <p><strong>Tips:</strong> Get your head around quickly—this is often a hot read or first look in progression.</p>
+                </article>
 
-                <h3>1. Flat</h3>
-                <p><strong>Setup:</strong> Usually from a tight or slot alignment. May motion to adjust leverage.</p>
-                <p><strong>Directions:</strong> Release horizontally toward the sideline, staying flat and gaining width.</p>
-                <p><strong>Tips:</strong> Get your head around quickly—this is often a hot read or first look in progression.</p>
+                <article class="route-card">
+                    <h3>2. Slant</h3>
+                    <p><strong>Setup:</strong> Start with an inside foot back. Lean inside to threaten vertical then break sharp.</p>
+                    <p><strong>Directions:</strong> Take 1–3 steps vertically, then break at a 45° angle across the defender’s face.</p>
+                    <p><strong>Tips:</strong> Speed is critical. Win early. Use a subtle jab step if needed to get inside leverage.</p>
+                </article>
 
-                <h3>2. Slant</h3>
-                <p><strong>Setup:</strong> Start with an inside foot back. Lean inside to threaten vertical then break sharp.</p>
-                <p><strong>Directions:</strong> Take 1–3 steps vertically, then break at a 45° angle across the defender’s face.</p>
-                <p><strong>Tips:</strong> Speed is critical. Win early. Use a subtle jab step if needed to get inside leverage.</p>
+                <article class="route-card">
+                    <h3>3. Comeback</h3>
+                    <p><strong>Setup:</strong> Boundary side or isolated WR spot. Must sell vertical.</p>
+                    <p><strong>Directions:</strong> Push vertically to roughly 5 yards, then break back toward the sideline at a 45° angle.</p>
+                    <p><strong>Tips:</strong> Stay low and come out of the break flat. Don’t drift upfield. Timing with the QB is everything.</p>
+                </article>
 
-                <h3>3. Comeback</h3>
-                <p><strong>Setup:</strong> Boundary side or isolated WR spot. Must sell vertical.</p>
-                <p><strong>Directions:</strong> Push vertically to roughly 5 yards, then break back toward the sideline at a 45° angle.</p>
-                <p><strong>Tips:</strong> Stay low and come out of the break flat. Don’t drift upfield. Timing with the QB is everything.</p>
+                <article class="route-card">
+                    <h3>4. Curl / Hook / Hitch</h3>
+                    <p><strong>Setup:</strong> Wide or slot. Match depth to the concept (usually 8–12 yards).</p>
+                    <p><strong>Directions:</strong> Push vertical, snap down quickly, and come back to the QB, staying square.</p>
+                    <p><strong>Tips:</strong> Work into the soft spot of zone. Show strong hands and be ready to get vertical after the catch.</p>
+                </article>
 
-                <h3>4. Curl / Hook / Hitch</h3>
-                <p><strong>Setup:</strong> Wide or slot. Match depth to the concept (usually 8–12 yards).</p>
-                <p><strong>Directions:</strong> Push vertical, snap down quickly, and come back to the QB, staying square.</p>
-                <p><strong>Tips:</strong> Work into the soft spot of zone. Show strong hands and be ready to get vertical after the catch.</p>
+                <article class="route-card">
+                    <h3>5. Out</h3>
+                    <p><strong>Setup:</strong> Outside alignment with space from sideline. May motion for leverage.</p>
+                    <p><strong>Directions:</strong> Push vertical to 5 or 10 yards, then break sharply at 90° toward the sideline.</p>
+                    <p><strong>Tips:</strong> Stay flat on your break. Do not round it. Timing route—ball is coming out quick.</p>
+                </article>
 
-                <h3>5. Out</h3>
-                <p><strong>Setup:</strong> Outside alignment with space from sideline. May motion for leverage.</p>
-                <p><strong>Directions:</strong> Push vertical to 5 or 10 yards, then break sharply at 90° toward the sideline.</p>
-                <p><strong>Tips:</strong> Stay flat on your break. Do not round it. Timing route—ball is coming out quick.</p>
+                <article class="route-card">
+                    <h3>6. In (Dig)</h3>
+                    <p><strong>Setup:</strong> Mid or wide split. Use inside leverage off the line.</p>
+                    <p><strong>Directions:</strong> Push vertical to 5 or 10 yards, then break inside across the field at 90°.</p>
+                    <p><strong>Tips:</strong> Stay flat and accelerate through the route. Expect contact and work through it.</p>
+                </article>
 
-                <h3>6. In (Dig)</h3>
-                <p><strong>Setup:</strong> Mid or wide split. Use inside leverage off the line.</p>
-                <p><strong>Directions:</strong> Push vertical to 5 or 10 yards, then break inside across the field at 90°.</p>
-                <p><strong>Tips:</strong> Stay flat and accelerate through the route. Expect contact and work through it.</p>
+                <article class="route-card">
+                    <h3>7. Corner</h3>
+                    <p><strong>Setup:</strong> Outside release preferred. Sell post to force the DB inside.</p>
+                    <p><strong>Directions:</strong> Stem to 5 yards, then break at a 45° angle toward the pylon or sideline.</p>
+                    <p><strong>Tips:</strong> Keep eyes upfield and don't tip the break. Lean inside just before cutting.</p>
+                </article>
 
-                <h3>7. Corner</h3>
-                <p><strong>Setup:</strong> Outside release preferred. Sell post to force the DB inside.</p>
-                <p><strong>Directions:</strong> Stem to 5 yards, then break at a 45° angle toward the pylon or sideline.</p>
-                <p><strong>Tips:</strong> Keep eyes upfield and don't tip the break. Lean inside just before cutting.</p>
+                <article class="route-card">
+                    <h3>8. Post</h3>
+                    <p><strong>Setup:</strong> Outside release with vertical stem. Room to cut inside is essential.</p>
+                    <p><strong>Directions:</strong> Break at 5 yards on a 45° angle toward the center/post.</p>
+                    <p><strong>Tips:</strong> Sell go route before snapping inside. Make the cut crisp and accelerate through the catch window.</p>
+                </article>
 
-                <h3>8. Post</h3>
-                <p><strong>Setup:</strong> Outside release with vertical stem. Room to cut inside is essential.</p>
-                <p><strong>Directions:</strong> Break at 5 yards on a 45° angle toward the center/post.</p>
-                <p><strong>Tips:</strong> Sell go route before snapping inside. Make the cut crisp and accelerate through the catch window.</p>
-
-                <h3>9. Go / Fade / Fly</h3>
-                <p><strong>Setup:</strong> Any alignment. On the outside, use a split-release to beat press.</p>
-                <p><strong>Directions:</strong> Sprint vertical at full speed. Stay outside the numbers unless stacked.</p>
-                <p><strong>Tips:</strong> Don’t look for the ball too early. Stack the DB or win outside leverage and hold your line.</p>
+                <article class="route-card">
+                    <h3>9. Go / Fade / Fly</h3>
+                    <p><strong>Setup:</strong> Any alignment. On the outside, use a split-release to beat press.</p>
+                    <p><strong>Directions:</strong> Sprint vertical at full speed. Stay outside the numbers unless stacked.</p>
+                    <p><strong>Tips:</strong> Don’t look for the ball too early. Stack the DB or win outside leverage and hold your line.</p>
+                </article>
             </section>
         </article>
     </main>

--- a/website/styles.css
+++ b/website/styles.css
@@ -837,3 +837,41 @@ footer p {
     padding: 1rem 0;
   }
 }
+
+/* Route Card Styles */
+.route-grid-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); /* Responsive columns */
+  gap: var(--space-lg);
+  padding-top: var(--space-lg); /* Add some space above the grid */
+}
+
+.route-card {
+  background-color: var(--color-white);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow-sm);
+  padding: var(--space-lg);
+  margin-bottom: var(--space-lg); /* This will apply if not a direct grid item, or can be removed if gap is sufficient */
+  transition: box-shadow 0.2s ease-in-out;
+}
+
+.route-card:hover {
+  box-shadow: var(--box-shadow-md);
+}
+
+.route-card h3 {
+  font-size: var(--font-size-lg);
+  color: var(--color-primary);
+  margin-bottom: var(--space-md);
+}
+
+.route-card p {
+  font-size: var(--font-size-base);
+  margin-bottom: var(--space-sm);
+}
+
+.route-card p strong { /* For "Setup:", "Directions:", "Tips:" labels */
+  color: var(--color-primary-dark);
+  margin-right: var(--space-xs);
+}


### PR DESCRIPTION
This commit refactors the "Wide Receiver Routes" section on the football_101/offense/theWideReceiver.html page to enhance visual appeal and readability.

Key changes:
- Each route description is now presented as a card using an `<article class="route-card">` element.
- Screen route sub-types (Bubble, Slip, Tunnel) are now individual cards for consistency.
- A responsive grid layout (.route-grid-container) is implemented using CSS Grid, displaying 2-3 cards per row on wider screens and stacking them vertically on smaller screens.
- New CSS styles for .route-card and .route-grid-container have been added to styles.css, utilizing existing CSS variables for consistency with the site's design.
- The introductory paragraph for the routes section has been correctly positioned before the grid of route cards.

These changes make the route information easier to scan, digest, and more engaging for you, while maintaining mobile-friendliness.