### PR TITLE
Add structured layout for passing concepts

### DIFF
--- a/concept_card_structure.html
+++ b/concept_card_structure.html
@@ -1,0 +1,5 @@
+<div class="passing-concept-card">
+  <h3>Play Name Example</h3>
+  <div class="concept-description"></div>
+  <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+</div>

--- a/website/pages/football_101/offense/passingConcepts.html
+++ b/website/pages/football_101/offense/passingConcepts.html
@@ -38,9 +38,75 @@
             <!-- More content can be added here -->
         </section>
 
+        <section>
+            <h2>Key Passing Concepts</h2>
+            <div class="passing-concepts-container">
+                <div class="passing-concept-card">
+                    <h3>Mesh</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Levels</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Flood</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Smash</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Y-Cross</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Four Verticals</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Stick</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Drive</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Dagger</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Slant-Flat</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Double China</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+                <div class="passing-concept-card">
+                    <h3>Shallow Cross</h3>
+                    <div class="concept-description"></div>
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
+                </div>
+            </div>
+        </section>
+
         <!-- Add more sections as needed -->
 
-        </article>
+        </div> <!-- Corrected closing tag for div class="container" -->
     </main>
 
     <div w3-include-html="../../../includes/footer.html"></div>

--- a/website/styles.css
+++ b/website/styles.css
@@ -1019,3 +1019,72 @@ footer p {
     padding: var(--space-xs) var(--space-sm); /* Reduce padding in table cells */
   }
 }
+
+/* Passing Concept Card Styles */
+.passing-concepts-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-lg, 20px); /* Use variable or fallback */
+  justify-content: center; /* Center cards if they don't fill the row */
+  padding: var(--space-lg, 20px) 0; /* Add some padding around the container */
+}
+
+.passing-concept-card {
+  border: 1px solid #ccc;
+  padding: var(--space-md, 16px); /* Use variable or fallback */
+  margin-bottom: var(--space-lg, 20px); /* Use variable or fallback */
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  background-color: var(--color-white, #fff); /* Use variable or fallback */
+  border-radius: var(--border-radius, 0.3rem); /* Use variable or fallback */
+  /* Flex item properties for the container */
+  flex: 0 1 calc(33.333% - var(--space-lg, 20px)); /* Default for 3 cards per row */
+  max-width: calc(33.333% - var(--space-lg, 20px)); /* Ensure it doesn't exceed 33.333% */
+}
+
+.passing-concept-card h3 {
+  color: var(--color-primary-dark, #133728); /* Use variable or fallback */
+  margin-bottom: var(--space-md, 10px); /* Use variable or fallback */
+}
+
+.concept-description {
+  margin-bottom: var(--space-md, 10px); /* Use variable or fallback */
+  font-size: var(--font-size-base, 1rem); /* Use variable or fallback */
+  line-height: var(--line-height-base, 1.6); /* Use variable or fallback */
+  color: var(--color-dark, #343a40); /* Use variable or fallback */
+  flex-grow: 1; /* Allows description to take available space */
+}
+
+.concept-diagram-placeholder {
+  border: 1px dashed #aaa;
+  padding: var(--space-lg, 20px); /* Use variable or fallback */
+  text-align: center;
+  margin-bottom: var(--space-md, 10px); /* Use variable or fallback */
+  background-color: #f8f9fa; /* Light background for placeholder */
+  color: #6c757d; /* Muted text color */
+  min-height: 150px; /* Ensure it has some height */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--border-radius, 0.3rem);
+}
+
+/* Responsive design for passing concept cards */
+@media (max-width: 991.98px) { /* Medium screens, e.g. tablets, for 2 cards per row */
+  .passing-concept-card {
+    flex: 0 1 calc(50% - var(--space-lg, 20px)); /* 2 cards per row */
+    max-width: calc(50% - var(--space-lg, 20px));
+  }
+}
+
+@media (max-width: 767.98px) { /* Small screens, e.g. mobile phones, for 1 card per row */
+  .passing-concepts-container {
+    padding: var(--space-md, 16px) var(--space-sm, 8px); /* Reduce padding on smaller screens */
+  }
+  .passing-concept-card {
+    flex: 0 1 100%; /* Cards take full width and stack vertically */
+    max-width: 100%;
+    margin-bottom: var(--space-md, 16px); /* Adjust margin for stacked cards */
+  }
+}


### PR DESCRIPTION
This commit introduces a new section for "Key Passing Concepts" on the football_101/offense/passingConcepts.html page.

The following 12 passing concepts have been added, each with a dedicated card:
- Mesh
- Levels
- Flood
- Smash
- Y-Cross
- Four Verticals
- Stick
- Drive
- Dagger
- Slant-Flat
- Double China
- Shallow Cross

Each card includes:
- A heading for the play name.
- An empty div for a future description.
- A placeholder div labeled "Play Diagram Goes Here".

CSS has been added to style these cards for a clean, organized, and mobile-friendly presentation, using a flexbox container for responsive layout.