### PR TITLE
feat: Implement lightbox for passing concept diagrams

### DIFF
--- a/website/js/main.js
+++ b/website/js/main.js
@@ -114,3 +114,53 @@ document.querySelectorAll('.collapsible-button').forEach(button => {
         button.addEventListener('click', toggleCollapsible);
     }
 });
+
+// Lightbox functionality
+function initializeLightbox() {
+  const modal = document.getElementById('lightbox-modal');
+  if (!modal) {
+    // If the modal is not on this page, do nothing.
+    return;
+  }
+
+  const modalImg = document.getElementById('lightbox-image');
+  const closeButton = document.querySelector('.close-button');
+
+  const diagramPlaceholders = document.querySelectorAll('.concept-diagram-placeholder');
+
+  diagramPlaceholders.forEach(placeholder => {
+    const img = placeholder.querySelector('img');
+    if (img) {
+      img.onclick = function() {
+        modal.style.display = 'block';
+        modalImg.src = this.src;
+        modalImg.alt = this.alt; // Copy alt text for accessibility
+      }
+    }
+  });
+
+  if (closeButton) {
+    closeButton.onclick = function() {
+      modal.style.display = 'none';
+    }
+  }
+
+  // Close modal when clicking on the background
+  window.onclick = function(event) {
+    if (event.target == modal) {
+      modal.style.display = 'none';
+    }
+  }
+}
+
+// Call the function to initialize lightbox functionality
+// We need to ensure this runs after the DOM is loaded.
+// If there's an existing onload or DOMContentLoaded, add to it.
+// For simplicity, we'll try calling it directly.
+// If issues arise, we might need to hook into an existing DOM ready function.
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeLightbox);
+} else {
+    // DOMContentLoaded has already fired
+    initializeLightbox();
+}

--- a/website/pages/football_101/offense/passingConcepts.html
+++ b/website/pages/football_101/offense/passingConcepts.html
@@ -121,6 +121,10 @@
 
     <div w3-include-html="../../../includes/footer.html"></div>
 
+    <div id="lightbox-modal" class="modal">
+      <span class="close-button">&times;</span>
+      <img class="modal-content" id="lightbox-image">
+    </div>
     <script src="../../../js/main.js"></script>
     <script>
         includeHTML();

--- a/website/styles.css
+++ b/website/styles.css
@@ -1088,3 +1088,63 @@ footer p {
     margin-bottom: var(--space-md, 16px); /* Adjust margin for stacked cards */
   }
 }
+
+/* Lightbox Modal styles */
+.modal {
+  display: none; /* Hidden by default */
+  position: fixed; /* Stay in place */
+  z-index: 1000; /* Sit on top */
+  left: 0;
+  top: 0;
+  width: 100%; /* Full width */
+  height: 100%; /* Full height */
+  overflow: auto; /* Enable scroll if needed */
+  background-color: rgba(0,0,0,0.8); /* Black w/ opacity */
+  padding-top: 60px; /* Location of the box */
+}
+
+.modal-content {
+  margin: auto;
+  display: block;
+  width: 80%;
+  max-width: 700px;
+  border-radius: 8px;
+}
+
+/* Add Animation */
+.modal-content {
+  animation-name: zoom;
+  animation-duration: 0.6s;
+}
+
+@keyframes zoom {
+  from {transform:scale(0)}
+  to {transform:scale(1)}
+}
+
+.close-button {
+  position: absolute;
+  top: 15px;
+  right: 35px;
+  color: #f1f1f1;
+  font-size: 40px;
+  font-weight: bold;
+  transition: 0.3s;
+}
+
+.close-button:hover,
+.close-button:focus {
+  color: #bbb;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+/* Modify existing image placeholder to indicate interactivity */
+.concept-diagram-placeholder img {
+  cursor: pointer;
+  transition: 0.3s;
+}
+
+.concept-diagram-placeholder img:hover {
+  opacity: 0.7;
+}


### PR DESCRIPTION
I've added a lightbox feature to `passingConcepts.html` that allows you to click on passing concept diagrams to view a larger version in a modal overlay.

Changes include:
- Added HTML structure for the modal to `passingConcepts.html`.
- Added CSS styles for the modal, overlay, image, and close button to `styles.css`. This also includes a hover effect on diagram images.
- Added JavaScript functionality to `main.js` to handle:
    - Opening the modal and displaying the correct image on click.
    - Closing the modal via a close button or by clicking the overlay.
- Ensured the JavaScript initializes correctly after the DOM is loaded and handles cases where the modal is not present on a page.