### PR TITLE
Refactor: Improve layout of passing concepts page

### DIFF
--- a/website/pages/football_101/offense/passingConcepts.html
+++ b/website/pages/football_101/offense/passingConcepts.html
@@ -42,6 +42,9 @@
             <h2>Key Passing Concepts</h2>
             <div class="passing-concepts-container">
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">
+                        <img src="../../../images/mesh.png" alt="Mesh Passing Concept Diagram" style="max-width: 100%; height: auto; border-radius: 8px;" />
+                    </div>
                     <h3>Mesh</h3>
                     <div class="concept-description">
                         <p><strong>Overview:</strong> The Mesh concept is one of the most effective ways to create separation versus man coverage, and it still works against zone. It’s all about creating natural traffic across the middle of the field by having two receivers run shallow crossing routes at nearly the same depth.</p>
@@ -52,64 +55,61 @@
 
                         <p><strong>Why We Use It:</strong> At every level, defenders struggle to navigate the traffic created by these shallow routes. At the youth level, you get kids wide open just from the confusion. It's simple to teach but hard to defend. The key is timing and spacing—it’s controlled chaos that we use to get guys free.</p>
                     </div>
-                    <div class="concept-diagram-placeholder">
-                        <img src="../../../images/mesh.png" alt="Mesh Passing Concept Diagram" style="max-width: 100%; height: auto; border-radius: 8px;" />
-                    </div>
                 </div>           
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Levels</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Flood</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Smash</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Y-Cross</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Four Verticals</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Stick</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Drive</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Dagger</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Slant-Flat</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Double China</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
                 <div class="passing-concept-card">
+                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                     <h3>Shallow Cross</h3>
                     <div class="concept-description"></div>
-                    <div class="concept-diagram-placeholder">Play Diagram Goes Here</div>
                 </div>
             </div>
         </section>

--- a/website/styles.css
+++ b/website/styles.css
@@ -1039,16 +1039,18 @@ footer p {
   background-color: var(--color-white, #fff); /* Use variable or fallback */
   border-radius: var(--border-radius, 0.3rem); /* Use variable or fallback */
   /* Flex item properties for the container */
-  flex: 0 1 calc(33.333% - var(--space-lg, 20px)); /* Default for 3 cards per row */
-  max-width: calc(33.333% - var(--space-lg, 20px)); /* Ensure it doesn't exceed 33.333% */
+  flex: 0 1 calc(50% - var(--space-lg, 20px)); /* Default for 2 cards per row */
+  max-width: calc(50% - var(--space-lg, 20px)); /* Ensure it doesn't exceed 50% */
 }
 
 .passing-concept-card h3 {
   color: var(--color-primary-dark, #133728); /* Use variable or fallback */
   margin-bottom: var(--space-md, 10px); /* Use variable or fallback */
+  margin-top: var(--space-sm); /* Add space between image and title */
 }
 
 .concept-description {
+  width: 100%; /* Ensure it uses the full width within the card */
   margin-bottom: var(--space-md, 10px); /* Use variable or fallback */
   font-size: var(--font-size-base, 1rem); /* Use variable or fallback */
   line-height: var(--line-height-base, 1.6); /* Use variable or fallback */
@@ -1057,26 +1059,27 @@ footer p {
 }
 
 .concept-diagram-placeholder {
-  border: 1px dashed #aaa;
-  padding: var(--space-lg, 20px); /* Use variable or fallback */
-  text-align: center;
+  /* border: 1px dashed #aaa; */ /* Removed */
+  /* padding: var(--space-lg, 20px); */ /* Removed */
+  /* text-align: center; */ /* Removed as image is block and 100% width */
   margin-bottom: var(--space-md, 10px); /* Use variable or fallback */
-  background-color: #f8f9fa; /* Light background for placeholder */
-  color: #6c757d; /* Muted text color */
-  min-height: 150px; /* Ensure it has some height */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--border-radius, 0.3rem);
+  /* background-color: #f8f9fa; */ /* Removed */
+  /* color: #6c757d; */ /* Removed */
+  /* min-height: 150px; */ /* Removed */
+  display: block; /* Changed from flex to block */
+  /* align-items: center; */ /* Removed as it's for flex */
+  /* justify-content: center; */ /* Removed as it's for flex */
+  border-radius: var(--border-radius, 0.3rem); /* Keep radius for the image if image itself doesn't have it */
 }
 
 /* Responsive design for passing concept cards */
-@media (max-width: 991.98px) { /* Medium screens, e.g. tablets, for 2 cards per row */
-  .passing-concept-card {
-    flex: 0 1 calc(50% - var(--space-lg, 20px)); /* 2 cards per row */
-    max-width: calc(50% - var(--space-lg, 20px));
-  }
-}
+/* Default is now 2 cards per row, so the 991.98px media query for this specific case is no longer needed. */
+/* @media (max-width: 991.98px) { */ /* Medium screens, e.g. tablets, for 2 cards per row */
+  /* .passing-concept-card { */
+    /* flex: 0 1 calc(50% - var(--space-lg, 20px)); */ /* 2 cards per row */
+    /* max-width: calc(50% - var(--space-lg, 20px)); */
+  /* } */
+/* } */
 
 @media (max-width: 767.98px) { /* Small screens, e.g. mobile phones, for 1 card per row */
   .passing-concepts-container {
@@ -1141,6 +1144,10 @@ footer p {
 
 /* Modify existing image placeholder to indicate interactivity */
 .concept-diagram-placeholder img {
+  width: 100%; /* Ensure image takes full width of the placeholder */
+  height: auto; /* Maintain aspect ratio */
+  display: block; /* Already global, but good for specificity */
+  border-radius: var(--border-radius); /* Ensure image itself has the radius */
   cursor: pointer;
   transition: 0.3s;
 }


### PR DESCRIPTION
This commit updates the `website/pages/football_101/offense/passingConcepts.html` page and its associated CSS (`website/styles.css`) to enhance the visual prominence of play diagrams and improve overall layout and responsiveness.

Key changes include:

-   **HTML Structure:** Reordered elements within each passing concept card to place the play diagram image (in `.concept-diagram-placeholder`) before the title (`h3`) and textual description (`.concept-description`).
-   **CSS Styling:**
    -   Made play diagram images larger by default (full width of their container).
    -   Removed unnecessary borders and backgrounds from the image placeholder div, allowing the image itself to be the focus.
    -   Adjusted the main passing concept card layout on desktop screens from three columns to two columns, providing more space for the enlarged images.
    -   Ensured the layout remains responsive, collapsing to a single column on mobile devices with the image at the top.
    -   Verified that text content presentation remains clear and mobile-friendly, leveraging existing CSS variables for typography and spacing.
    -   Preserved the existing lightbox functionality for viewing larger versions of the play diagrams.

These changes address the issue of play diagrams being too small and not the primary visual focus, resulting in a more intuitive and user-friendly presentation of passing concepts.