### PR TITLE
Fix: Header overlapping content on all pages

### DIFF
--- a/website/styles.css
+++ b/website/styles.css
@@ -136,7 +136,7 @@ header {
   color: var(--color-light);
   padding: 0; /* Remove header padding, let sections inside control it */
   box-shadow: var(--box-shadow-sm); /* Keep this for the overall header block */
-  position: fixed;
+  position: sticky;
   top: 0;
   left: 0;
   width: 100%;
@@ -229,7 +229,7 @@ nav.site-navigation li.submenu-active > ul { /* For click nav from main.js */
 
 /* Main Content */
 main {
-  padding: 180px 0 var(--space-xl); /* Use container for side padding */
+  padding: 0 0 var(--space-xl); /* Use container for side padding */
 }
 
 /* Styling for the container of articles on index.html */
@@ -482,7 +482,7 @@ footer p {
   }
 
   main {
-    padding: 180px 0 var(--space-xl); /* Adjusted top padding for mobile - REVERTED to original desktop padding as dropdowns now overlay */
+    padding: 0 0 var(--space-xl); /* Adjusted top padding for mobile - REVERTED to original desktop padding as dropdowns now overlay */
   }
 }
 


### PR DESCRIPTION
The header was previously using `position: fixed`, which caused it to overlap the main content of the pages.

This commit changes the header's CSS to use `position: sticky`. This ensures the header remains at the top of the viewport during scroll while still occupying space in the normal document flow, thus preventing overlap.

Additionally, the `padding-top` on the `main` element was reviewed and adjusted:
- Removed a fixed `180px` top padding from the general `main` style.
- Removed a specific `180px` top padding from the `main` style within the mobile media query (`@media (max-width: 767.98px)`), as it was causing excessive spacing on mobile devices with the new sticky header.

These changes should ensure the header displays correctly without overlapping content on both desktop and mobile views.